### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ An example config running selenium tests for multiple browsers in parallel with 
 ```yaml
 version: 2.1
 orbs:
-  saucelabs: saucelabs/connects@volatile
+  saucelabs: saucelabs/connects@x.y.z
 workflows:
   browser_tests:
     jobs:

--- a/sample.yml
+++ b/sample.yml
@@ -1,7 +1,7 @@
 version: 2.1
 orbs:
   # TODO: change to saucelabs: saucelabs/connects@volatile once transitioned
-  saucelabs: sandbox/saucelabs@volatile
+  saucelabs: sandbox/saucelabs@x.y.z
 workflows:
   basic_workflow:
     jobs:


### PR DESCRIPTION
`volatile` is not a best practice, we use `x.y.z` in our own first-party orb documentation in order to convey the basics of orb semantic versioning, without hardcoding a particular version