### PR TITLE
Add link to homepage and orb source

### DIFF
--- a/src/@orb.yml
+++ b/src/@orb.yml
@@ -1,7 +1,10 @@
 version: 2.1
 description: >
   Encapsulates interactions with Sauce Connect Proxy
-  The source repo for this ORB can be found here: https://github.com/saucelabs-sample-test-frameworks/CircleCI-SauceLabs-ORB
+
+display:
+  source_url: https://github.com/saucelabs-sample-test-frameworks/CircleCI-SauceLabs-ORB
+  home_url: https://saucelabs.com/
 
 commands:
   install:


### PR DESCRIPTION
This addition will create a link to your home page and the orb source natively as a clickable link in the orb repository.